### PR TITLE
rock/parser: refactoring

### DIFF
--- a/rock_parser/src/profile/function.rs
+++ b/rock_parser/src/profile/function.rs
@@ -1,4 +1,4 @@
-use crate::profile::buffer::{decode_field, Buffer};
+use crate::profile::buffer::{Buffer};
 use crate::profile::Decoder;
 use std::default::Default;
 
@@ -26,46 +26,34 @@ pub struct Function {
 }
 
 impl Decoder<Function> for Function {
-    #[inline]
-    fn decode(buf: &mut Buffer, data: &mut Vec<u8>) -> Function {
-        let mut func = Function::default();
-        while !data.is_empty() {
-            match decode_field(buf, data) {
-                Ok(_) => {
-                    match buf.field {
-                        // optional uint64 id = 1
-                        1 => {
-                            func.id = buf.u64;
-                        }
-                        // optional int64 function_name = 2
-                        // index to string table
-                        2 => {
-                            func.name_index = buf.u64 as i64;
-                        }
-                        // optional int64 function_system_name = 3
-                        // index to string table
-                        3 => {
-                            func.system_name_index = buf.u64 as i64;
-                        }
-                        // repeated int64 filename = 4
-                        // index to string table
-                        4 => {
-                            func.filename_index = buf.u64 as i64;
-                        }
-                        // optional int64 start_line = 5
-                        5 => {
-                            func.start_line = buf.u64 as i64;
-                        }
-                        _ => {
-                            panic!("Unknown function type");
-                        }
-                    }
-                }
-                Err(err) => {
-                    panic!(err);
-                }
+    fn fill(buf: &mut Buffer, func: &mut Function) {
+        match buf.field {
+            // optional uint64 id = 1
+            1 => {
+                func.id = buf.u64;
+            }
+            // optional int64 function_name = 2
+            // index to string table
+            2 => {
+                func.name_index = buf.u64 as i64;
+            }
+            // optional int64 function_system_name = 3
+            // index to string table
+            3 => {
+                func.system_name_index = buf.u64 as i64;
+            }
+            // repeated int64 filename = 4
+            // index to string table
+            4 => {
+                func.filename_index = buf.u64 as i64;
+            }
+            // optional int64 start_line = 5
+            5 => {
+                func.start_line = buf.u64 as i64;
+            }
+            _ => {
+                panic!("Unknown function type");
             }
         }
-        func
     }
 }

--- a/rock_parser/src/profile/label.rs
+++ b/rock_parser/src/profile/label.rs
@@ -1,4 +1,4 @@
-use crate::profile::buffer::{decode_field, Buffer};
+use crate::profile::buffer::{Buffer};
 use crate::profile::Decoder;
 
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
@@ -21,40 +21,27 @@ pub struct Label {
 }
 
 impl Decoder<Label> for Label {
-    #[inline]
-    fn decode(buf: &mut Buffer, data: &mut Vec<u8>) -> Label {
-        let mut lb = Label::default();
-        while !data.is_empty() {
-            match decode_field(buf, data) {
-                Ok(_) => {
-                    match buf.field {
-                        //1
-                        1 => {
-                            lb.key_index = buf.u64 as i64;
-                        }
-                        //2
-                        2 => {
-                            lb.str_index = buf.u64 as i64;
-                        }
-                        //3
-                        3 => {
-                            lb.num_index = buf.u64 as i64;
-                        }
-                        //4
-                        4 => {
-                            lb.num_unit_index = buf.u64 as i64;
-                        }
-                        _ => {
-                            panic!("Unknown label type");
-                        }
-                    }
-                }
-                Err(err) => {
-                    panic!(err);
-                }
+    fn fill(buf: &mut Buffer, lb: &mut Label) {
+        match buf.field {
+            //1
+            1 => {
+                lb.key_index = buf.u64 as i64;
+            }
+            //2
+            2 => {
+                lb.str_index = buf.u64 as i64;
+            }
+            //3
+            3 => {
+                lb.num_index = buf.u64 as i64;
+            }
+            //4
+            4 => {
+                lb.num_unit_index = buf.u64 as i64;
+            }
+            _ => {
+                panic!("Unknown label type");
             }
         }
-
-        lb
     }
 }

--- a/rock_parser/src/profile/line.rs
+++ b/rock_parser/src/profile/line.rs
@@ -1,4 +1,4 @@
-use crate::profile::buffer::{decode_field, Buffer};
+use crate::profile::buffer::{Buffer};
 use crate::profile::{function, Decoder};
 
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
@@ -13,31 +13,19 @@ pub struct Line {
 }
 
 impl Decoder<Line> for Line {
-    #[inline]
-    fn decode(buf: &mut Buffer, data: &mut Vec<u8>) -> Line {
-        let mut line = Line::default();
-        while !data.is_empty() {
-            match decode_field(buf, data) {
-                Ok(_) => {
-                    match buf.field {
-                        // optional uint64 function_id = 1
-                        1 => {
-                            line.function_index = buf.u64;
-                        }
-                        // optional int64 line = 2
-                        2 => {
-                            line.line = buf.u64 as i64;
-                        }
-                        _ => {
-                            panic!("Unknown line type");
-                        }
-                    }
-                }
-                Err(err) => {
-                    panic!(err);
-                }
+    fn fill(buf: &mut Buffer, line: &mut Line) {
+        match buf.field {
+            // optional uint64 function_id = 1
+            1 => {
+                line.function_index = buf.u64;
+            }
+            // optional int64 line = 2
+            2 => {
+                line.line = buf.u64 as i64;
+            }
+            _ => {
+                panic!("Unknown line type");
             }
         }
-        line
     }
 }

--- a/rock_parser/src/profile/location.rs
+++ b/rock_parser/src/profile/location.rs
@@ -1,4 +1,4 @@
-use crate::profile::buffer::{decode_field, Buffer};
+use crate::profile::buffer::{Buffer};
 use crate::profile::mapping::Mapping;
 use crate::profile::{function, line, Decoder};
 
@@ -38,48 +38,36 @@ pub struct Location {
 }
 
 impl Decoder<Location> for Location {
-    #[inline]
-    fn decode(buf: &mut Buffer, data: &mut Vec<u8>) -> Location {
-        let mut loc = Location::default();
-        while !data.is_empty() {
-            match decode_field(buf, data) {
-                Ok(ref mut buf_data) => {
-                    match buf.field {
-                        // optional uint64 function_id = 1
-                        1 => {
-                            loc.id = buf.u64;
-                        }
-                        // optional int64 line = 2
-                        2 => {
-                            loc.mapping_index = buf.u64;
-                        }
-                        // optional uint64 address = 3;
-                        3 => {
-                            loc.address = buf.u64;
-                        }
-                        // repeated Line line = 4
-                        4 => {
-                            // todo!(why buf copied twice) ?????
-                            loc.line.push(line::Line::decode(buf, buf_data));
-                        }
-                        5 => {
-                            if buf.u64 == 0 {
-                                loc.is_folder = false
-                            } else {
-                                loc.is_folder = true
-                            }
-                        }
-                        _ => {
-                            panic!("Unknown location type");
-                        }
-                    }
-                }
-                Err(err) => {
-                    panic!(err);
+    fn fill(buf: &mut Buffer, loc: &mut Location) {
+        match buf.field {
+            // optional uint64 function_id = 1
+            1 => {
+                loc.id = buf.u64;
+            }
+            // optional int64 line = 2
+            2 => {
+                loc.mapping_index = buf.u64;
+            }
+            // optional uint64 address = 3;
+            3 => {
+                loc.address = buf.u64;
+            }
+            // repeated Line line = 4
+            4 => {
+                // todo!(why buf copied twice) ?????
+                loc.line.push(line::Line::decode(buf));
+            }
+            5 => {
+                if buf.u64 == 0 {
+                    loc.is_folder = false
+                } else {
+                    loc.is_folder = true
                 }
             }
+            _ => {
+                panic!("Unknown location type");
+            }
         }
-        loc
     }
 }
 

--- a/rock_parser/src/profile/mapping.rs
+++ b/rock_parser/src/profile/mapping.rs
@@ -1,4 +1,4 @@
-use crate::profile::buffer::{decode_field, Buffer};
+use crate::profile::buffer::{Buffer};
 use crate::profile::Decoder;
 use std::default::Default;
 
@@ -37,77 +37,65 @@ pub struct Mapping {
 }
 
 impl Decoder<Mapping> for Mapping {
-    #[inline]
-    fn decode(buf: &mut Buffer, data: &mut Vec<u8>) -> Mapping {
-        let mut mapping = Mapping::default();
-        while !data.is_empty() {
-            match decode_field(buf, data) {
-                Ok(_) => {
-                    match buf.field {
-                        //1
-                        1 => {
-                            mapping.id = buf.u64;
-                        }
-                        //2
-                        2 => {
-                            mapping.memory_start = buf.u64;
-                        }
-                        //3
-                        3 => {
-                            mapping.memory_limit = buf.u64;
-                        }
-                        //4
-                        4 => {
-                            mapping.memory_offset = buf.u64;
-                        }
-                        //5
-                        5 => {
-                            mapping.filename_index = buf.u64 as i64;
-                        }
-                        //6
-                        6 => {
-                            mapping.build_id_index = buf.u64 as i64;
-                        }
-                        //7
-                        7 => {
-                            if buf.u64 == 0 {
-                                mapping.has_function = false;
-                            } else {
-                                mapping.has_function = true;
-                            }
-                        }
-                        //8
-                        8 => match buf.u64 {
-                            0 => mapping.has_filenames = false,
-                            _ => mapping.has_filenames = true,
-                        },
-                        //9
-                        9 => {
-                            if buf.u64 == 0 {
-                                mapping.has_line_numbers = false;
-                            } else {
-                                mapping.has_line_numbers = true;
-                            }
-                        }
-                        //10
-                        10 => {
-                            if buf.u64 == 0 {
-                                mapping.has_inline_frames = false;
-                            } else {
-                                mapping.has_inline_frames = true;
-                            }
-                        }
-                        _ => {
-                            panic!("Unknown mapping type");
-                        }
-                    }
-                }
-                Err(err) => {
-                    panic!(err);
+    fn fill(buf: &mut Buffer, mapping: &mut Mapping) {
+        match buf.field {
+            //1
+            1 => {
+                mapping.id = buf.u64;
+            }
+            //2
+            2 => {
+                mapping.memory_start = buf.u64;
+            }
+            //3
+            3 => {
+                mapping.memory_limit = buf.u64;
+            }
+            //4
+            4 => {
+                mapping.memory_offset = buf.u64;
+            }
+            //5
+            5 => {
+                mapping.filename_index = buf.u64 as i64;
+            }
+            //6
+            6 => {
+                mapping.build_id_index = buf.u64 as i64;
+            }
+            //7
+            7 => {
+                if buf.u64 == 0 {
+                    mapping.has_function = false;
+                } else {
+                    mapping.has_function = true;
                 }
             }
+            //8
+            8 => match buf.u64 {
+                0 => mapping.has_filenames = false,
+                _ => mapping.has_filenames = true,
+            },
+            //9
+            9 => {
+                if buf.u64 == 0 {
+                    mapping.has_line_numbers = false;
+                } else {
+                    mapping.has_line_numbers = true;
+                }
+            }
+            //10
+            10 => {
+                if buf.u64 == 0 {
+                    mapping.has_inline_frames = false;
+                } else {
+                    mapping.has_inline_frames = true;
+                }
+            }
+            _ => {
+                panic!("Unknown mapping type");
+            }
         }
-        mapping
     }
 }
 

--- a/rock_parser/src/profile/value_type.rs
+++ b/rock_parser/src/profile/value_type.rs
@@ -1,4 +1,4 @@
-use crate::profile::buffer::{decode_field, Buffer};
+use crate::profile::buffer::{Buffer};
 use crate::profile::Decoder;
 
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
@@ -18,31 +18,19 @@ pub struct ValueType {
 }
 
 impl Decoder<ValueType> for ValueType {
-    #[inline]
-    fn decode(buf: &mut Buffer, data: &mut Vec<u8>) -> ValueType {
-        let mut vt = ValueType::default();
-        while !data.is_empty() {
-            match decode_field(buf, data) {
-                Ok(_) => {
-                    match buf.field {
-                        //1
-                        1 => {
-                            vt.type_index = buf.u64 as i64;
-                        }
-                        //2
-                        2 => {
-                            vt.unit_index = buf.u64 as i64;
-                        }
-                        _ => {
-                            panic!("Unknown value_type type");
-                        }
-                    }
-                }
-                Err(err) => {
-                    panic!(err);
-                }
+    fn fill(buf: &mut Buffer, vt: &mut ValueType) {
+        match buf.field {
+            //1
+            1 => {
+                vt.type_index = buf.u64 as i64;
+            }
+            //2
+            2 => {
+                vt.unit_index = buf.u64 as i64;
+            }
+            _ => {
+                panic!("Unknown value_type type");
             }
         }
-        vt
     }
 }


### PR DESCRIPTION
Coincidentally run into the repository. I've been curious how profiles works internally so I kinda stuck here for a bit and decided to provide this small PR. I see that it's a WIP project. But I supposed that it is not a problem for this PR :).

The PR reduces a redundancy in parser's code.

The bigetst chunck of changes is located in d1549a1 where the trait `Decoder` was stylished a bit.

I saw in code that `Buffer` had a data field but it's not now, but I take it to be a good place for data so I recovered it.

I am not sufficient in the codebase and might misunderstand some weird concepts there. And the changes were barely tested but they are not intended to have any influence on the logic.

By the way I'd love to ask you unrelated question, if you don't mind. What the reason of usage a custom allocator here?